### PR TITLE
Use EVT_KEY_FIRST(KEY_EXIT) instead of EVT_KEY_BREAK() in FormGroup

### DIFF
--- a/src/form.cpp
+++ b/src/form.cpp
@@ -225,20 +225,18 @@ void FormGroup::onEvent(event_t event)
   if (event == EVT_KEY_BREAK(KEY_ENTER)) {
     onKeyPress();
     setFocusOnFirstVisibleField(SET_FOCUS_FIRST);
-  }
-  else if (event == EVT_KEY_BREAK(KEY_EXIT) && !hasFocus() && !(windowFlags & FORM_FORWARD_FOCUS)) {
+  } else if (event == EVT_KEY_FIRST(KEY_EXIT) && !hasFocus() &&
+             !(windowFlags & FORM_FORWARD_FOCUS)) {
+    killEvents(event);
     onKeyPress();
-    setFocus(SET_FOCUS_DEFAULT); // opentx - model - timers settings
-  }
-  else if (event == EVT_ROTARY_RIGHT && !next) {
+    setFocus(SET_FOCUS_DEFAULT);  // opentx - model - timers settings
+  } else if (event == EVT_ROTARY_RIGHT && !next) {
     onKeyPress();
     setFocusOnFirstVisibleField(SET_FOCUS_FIRST);
-  }
-  else if (event == EVT_ROTARY_LEFT && !previous) {
+  } else if (event == EVT_ROTARY_LEFT && !previous) {
     onKeyPress();
     setFocusOnLastVisibleField(SET_FOCUS_BACKWARD);
-  }
-  else {
+  } else {
     FormField::onEvent(event);
   }
 }


### PR DESCRIPTION
This prevents the TabGroup from catching the event first, and thus quit the complete page.
Resolves EdgeTX/edgetx#164