### PR TITLE
Long Touch functionality and number sign change by long press/touch.

### DIFF
--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -101,6 +101,13 @@ void NumberEdit::onEvent(event_t event)
         }
         return;
       }
+
+      case EVT_KEY_LONG(KEY_ENTER): {
+        int value = getValue();
+        if(-value < vmax && -value > vmin)
+          setValue(-value);
+        return;
+      } 
 #endif
 
       case EVT_KEY_FIRST(KEY_EXIT):
@@ -144,6 +151,14 @@ void NumberEdit::onEvent(event_t event)
 #if defined(HARDWARE_TOUCH)
 bool NumberEdit::onTouchEnd(coord_t, coord_t)
 {
+  Window::onTouchEnd(x, y);
+  if(isLongPress())
+  {
+    int value = getValue();
+    if(-value < vmax && -value > vmin)
+      setValue(-value);
+  }
+  
   if (!enabled) {
     return true;
   }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -38,6 +38,10 @@ Window::Window(Window * parent, const rect_t & rect, WindowFlags windowFlags, Lc
       invalidate();
     }
   }
+#if defined(HARDWARE_TOUCH)
+  duration10ms = 0;
+  touchDuration10ms = 0;
+#endif  
 }
 
 Window::~Window()

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -407,6 +407,10 @@ void Window::onEvent(event_t event)
 #if defined(HARDWARE_TOUCH)
 bool Window::onTouchStart(coord_t x, coord_t y)
 {
+  if(!duration10ms) {
+    duration10ms = get_tmr10ms();
+  }
+
   for (auto it = children.rbegin(); it != children.rend(); ++it) {
     auto child = *it;
     if (child->rect.contains(x, y)) {
@@ -435,6 +439,8 @@ bool Window::forwardTouchEnd(coord_t x, coord_t y)
 
 bool Window::onTouchEnd(coord_t x, coord_t y)
 {
+  touchDuration10ms = get_tmr10ms() - duration10ms;
+  duration10ms = 0;    
   return forwardTouchEnd(x, y) ? true : (windowFlags & OPAQUE);
 }
 

--- a/src/window.h
+++ b/src/window.h
@@ -30,6 +30,7 @@
 #include "libopenui_defines.h"
 #include "libopenui_helpers.h"
 #include "libopenui_config.h"
+#include "timers.h"
 
 typedef uint32_t WindowFlags;
 
@@ -49,6 +50,8 @@ constexpr WindowFlags REFRESH_ALWAYS =        1u << 5u;
 constexpr WindowFlags PAINT_CHILDREN_FIRST =  1u << 6u;
 constexpr WindowFlags PUSH_FRONT =  1u << 7u;
 constexpr WindowFlags WINDOW_FLAGS_LAST =  PUSH_FRONT;
+
+constexpr int LONG_PRESS_10MS = 100;
 
 enum SetFocusFlag
 {
@@ -427,6 +430,14 @@ class Window
     }
 
 #if defined(HARDWARE_TOUCH)
+    tmr10ms_t duration10ms;
+    tmr10ms_t touchDuration10ms;
+    
+    bool isLongPress(tmr10ms_t longPressDuration = LONG_PRESS_10MS)
+    {
+      return (touchDuration10ms > longPressDuration) ? true : false;
+    }
+
     static coord_t getSnapStep(coord_t relativeScrollPosition, coord_t pageSize);
 
     virtual bool onTouchStart(coord_t x, coord_t y);


### PR DESCRIPTION
Windows class differentiates short/long touches (1s).
Long touch/press on the number changes the sign (if possible).
This functionality will be used in another edgeTX feature: long press/touch on the switch changes it to !switch.