### PR TITLE
do not change window size when moving the top

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -501,7 +501,6 @@ void Window::moveWindowsTop(coord_t y, coord_t delta)
       invalidate();
     }
   }
-  setInnerHeight(innerHeight + delta);
 }
 
 void Window::invalidate(const rect_t & rect)


### PR DESCRIPTION
This is the fix for the ugliest portion of EdgeTX/edgeTX#620 when the bottom line of the trainer menu becomes inaccessible.
Window::moveWindowsTop(coord_t y, coord_t delta) in the EdgeTX code is called with the second argument adjustHeight(), so the window size is adjusted one extra time.
It also does not make too much sense "philosophically" to change the size of a window, when moving the top.