### PR TITLE
Software keyboard

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,5 +42,6 @@ if(SOFTWARE_KEYBOARD)
     ${LIBOPENUI_SRC}
     keyboard_text.cpp
     keyboard_number.cpp
+    keyboard_base.cpp
     )
 endif()

--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Source:
- *  https://github.com/opentx/libopenui
+ *  https://github.com/edgetx/libopenui
  *
  * This file is a part of libopenui library.
  *
@@ -43,7 +43,24 @@ void Keyboard::clearField()
   }
 }
 
-void Keyboard::setField(FormField* newField)
+coord_t calcScrollOffsetForField(FormField *newField, Window *topWindow)
+{
+  // now we need to calculate the offset of the field in the fields scroll container
+  // start with the current fields top and walk the hierarchy to calculate positon
+  coord_t offsetY = newField->top();
+
+  Window* parentWindow = newField->getParent();
+  while (parentWindow && parentWindow != topWindow) {
+    offsetY += parentWindow->top();
+    parentWindow = parentWindow->getParent();
+  }
+
+  // try and place it in the middle of the screen.  The containing window MUST have 
+  // already been resized
+  return offsetY - topWindow->height() / 2;
+}
+
+void Keyboard::attachKeyboard()
 {
   if (activeKeyboard) {
     if (activeKeyboard == this) return;
@@ -51,43 +68,49 @@ void Keyboard::setField(FormField* newField)
   }
   activeKeyboard = this;
   attach(MainWindow::instance());
+}
+
+
+// this routine finds the window that is a FormWindow.  This is the window
+// that contains all of the editable fields.  This is the window that needs
+// to be scrolled into view.
+FormWindow *Keyboard::findFormWindow()
+{
+  if (fieldContainer) {
+    auto children = fieldContainer->getChildren();
+    auto k = children.begin();
+    while (k != children.end())
+    {
+      FormWindow *a = dynamic_cast<FormWindow*>(*k);
+      if (a)
+        return a;
+      k++;
+    }
+  }
+
+  return nullptr;
+}
+
+void Keyboard::setField(FormField* newField)
+{
+  attachKeyboard();
 
   fieldContainer = getFieldContainer(newField);
   if (fieldContainer) {
-    coord_t newWindowHeight = LCD_H - height();
+    coord_t newHeight = LCD_H - height();
+    fieldContainer->setHeight(newHeight);
 
-    fieldContainer->setHeight(newWindowHeight);
+    fields = findFormWindow();
+    if (fields) {
+      // scroll the header of the window out of view to get more space to
+      // see the field being edited
+      fieldContainer->setScrollPositionY(fields->top());
+      oldHeight = fields->height();
+      fields->setHeight(newHeight);
 
-    std::list<Window*> children = fieldContainer->getChildren();
-    fields = *std::next(children.begin());
-
-    rect_t scrollRect = {
-      fieldContainer->left(), 
-      fields->top(),  // this will remove the title from the screen to provide extra visible space.
-      fieldContainer->width(),
-      fieldContainer->height()
-    };
-    // both should be the same height as we are scrolled to the right position 
-    fieldContainer->scrollTo(scrollRect);
-    oldHeight = fields->height();
-    fields->setHeight(newWindowHeight);
-
-    // now we need to calculate the offset of the field in the fields scroll container
-    coord_t offsetX = 0, offsetY = 0;
-    Window* parentWindow = newField->getParent();
-    while (parentWindow && parentWindow != fieldContainer) {
-      offsetX += parentWindow->left();
-      offsetY += parentWindow->top();
-      parentWindow = parentWindow->getParent();
+      coord_t offsetY = calcScrollOffsetForField(newField, fields);
+      fields->setScrollPositionY(offsetY);
     }
-
-    scrollRect = {
-      offsetX, 
-      offsetY + 69, 
-      fieldContainer->width(),
-      fieldContainer->height()
-    };
-    fields->scrollTo(scrollRect);
 
     invalidate();
     newField->setEditMode(true);

--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Source:
+ *  https://github.com/opentx/libopenui
+ *
+ * This file is a part of libopenui library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+#include "keyboard_base.h"
+
+void Keyboard::hide()
+{
+  if (activeKeyboard) {
+    activeKeyboard->clearField();
+    activeKeyboard = nullptr;
+  }
+}
+
+void Keyboard::clearField()
+{
+  detach();
+  if (fields) {
+    fields->setHeight(oldHeight);
+    fields = nullptr;
+  }
+  if (fieldContainer) {
+    fieldContainer->setHeight(LCD_H - 0 - fieldContainer->top());
+    fieldContainer = nullptr;
+  }
+  if (field) {
+    field->setEditMode(false);
+    field = nullptr;
+  }
+}
+
+void Keyboard::setField(FormField* newField)
+{
+  if (activeKeyboard) {
+    if (activeKeyboard == this) return;
+    activeKeyboard->clearField();
+  }
+  activeKeyboard = this;
+  attach(MainWindow::instance());
+
+  fieldContainer = getFieldContainer(newField);
+  if (fieldContainer) {
+    coord_t newWindowHeight = LCD_H - height();
+
+    fieldContainer->setHeight(newWindowHeight);
+
+    std::list<Window*> children = fieldContainer->getChildren();
+    fields = *std::next(children.begin());
+
+    rect_t scrollRect = {
+      fieldContainer->left(), 
+      fields->top(),  // this will remove the title from the screen to provide extra visible space.
+      fieldContainer->width(),
+      fieldContainer->height()
+    };
+    // both should be the same height as we are scrolled to the right position 
+    fieldContainer->scrollTo(scrollRect);
+    oldHeight = fields->height();
+    fields->setHeight(newWindowHeight);
+
+    // now we need to calculate the offset of the field in the fields scroll container
+    coord_t offsetX = 0, offsetY = 0;
+    Window* parentWindow = newField->getParent();
+    while (parentWindow && parentWindow != fieldContainer) {
+      offsetX += parentWindow->left();
+      offsetY += parentWindow->top();
+      parentWindow = parentWindow->getParent();
+    }
+
+    scrollRect = {
+      offsetX, 
+      offsetY + 69, 
+      fieldContainer->width(),
+      fieldContainer->height()
+    };
+    fields->scrollTo(scrollRect);
+
+    invalidate();
+    newField->setEditMode(true);
+    field = newField;
+  } else {
+    clearField();
+  }
+}
+
+Window* Keyboard::getFieldContainer(FormField* field)
+{
+  return field->getFullScreenWindow();
+}

--- a/src/keyboard_base.h
+++ b/src/keyboard_base.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Source:
- *  https://github.com/opentx/libopenui
+ *  https://github.com/edgetx/libopenui
  *
  * This file is a part of libopenui library.
  *
@@ -34,12 +34,14 @@ class Keyboard: public FormWindow
   protected:
     static Keyboard * activeKeyboard;
     FormField *field = nullptr;
-    Window    *fieldContainer = nullptr;
-    Window    *fields = nullptr;
-    coord_t    oldHeight = 0;
+    Window *fieldContainer = nullptr;
+    FormWindow *fields = nullptr;
+    coord_t oldHeight = 0;
 
     void setField(FormField *newField);
     void clearField();
     Window *getFieldContainer(FormField * field);
+    void attachKeyboard();
+    FormWindow *findFormWindow();
 };
 

--- a/src/keyboard_base.h
+++ b/src/keyboard_base.h
@@ -25,61 +25,21 @@
 class Keyboard: public FormWindow
 {
   public:
-    explicit Keyboard(coord_t height):
-      FormWindow(nullptr, {0, LCD_H - height, LCD_W, height}, OPAQUE)
+    explicit Keyboard(coord_t height) : FormWindow(nullptr, {0, LCD_H - height, LCD_W, height}, OPAQUE)
     {
     }
 
-    static void hide()
-    {
-      if (activeKeyboard) {
-        activeKeyboard->clearField();
-        activeKeyboard = nullptr;
-      }
-    }
+    static void hide();
 
   protected:
     static Keyboard * activeKeyboard;
-    FormField * field = nullptr;
-    Window * fieldContainer = nullptr;
+    FormField *field = nullptr;
+    Window    *fieldContainer = nullptr;
+    Window    *fields = nullptr;
+    coord_t    oldHeight = 0;
 
-    void setField(FormField * newField)
-    {
-      if (activeKeyboard) {
-        if (activeKeyboard == this)
-          return;
-        activeKeyboard->clearField();
-      }
-      activeKeyboard = this;
-      attach(MainWindow::instance());
-      fieldContainer = getFieldContainer(newField);
-      if (fieldContainer) {
-        fieldContainer->setHeight(LCD_H - height() - fieldContainer->top());
-        fieldContainer->scrollTo(newField);
-        invalidate();
-        newField->setEditMode(true);
-        field = newField;
-      } else {
-        clearField();
-      }
-    }
-
-    void clearField()
-    {
-      detach();
-      if (fieldContainer) {
-        fieldContainer->setHeight(LCD_H - 0 - fieldContainer->top());
-        fieldContainer = nullptr;
-      }
-      if (field) {
-        field->setEditMode(false);
-        field = nullptr;
-      }
-    }
-
-    Window * getFieldContainer(FormField * field)
-    {
-      return field->getFullScreenWindow();
-    }
+    void setField(FormField *newField);
+    void clearField();
+    Window *getFieldContainer(FormField * field);
 };
 

--- a/src/keyboard_text.cpp
+++ b/src/keyboard_text.cpp
@@ -174,7 +174,7 @@ void TextKeyboard::paint(BitmapBuffer * dc)
 
 bool TextKeyboard::onTouchStart(coord_t x, coord_t y)
 {
-    // remove the centering.  If x < 0 then this is an invalid touch event
+  // remove the centering.  If x < 0 then this is an invalid touch event
   x -= (this->width() - calculateMaxWidth()) / 2;
   if (x < 0) {
     if (touched) {
@@ -274,7 +274,7 @@ bool TextKeyboard::onTouchEnd(coord_t x, coord_t y)
       }
     }
     else {
-      if (x <= KEYBOARD_CHAR_WIDTH && *key != ' ') {
+      if (*key != ' ' && (x >= -(KEYBOARD_CHAR_WIDTH / 2) && x <= KEYBOARD_CHAR_WIDTH / 2)) {
         pushEvent(EVT_VIRTUAL_KEY(*key));
         return true;
       }

--- a/src/keyboard_text.h
+++ b/src/keyboard_text.h
@@ -29,6 +29,13 @@
 #define KEYBOARD_SET_LETTERS   "\203"
 #define KEYBOARD_SET_NUMBERS   "\204"
 
+#define KEYBOARD_OFFSET_Y 15
+#define KEYBOARD_ROW_HEIGHT 40
+#define KEYBOARD_CHAR_WIDTH 30
+#define KEYBOARD_SPACE_WIDTH 135
+#define KEYBOARD_ENTER_WIDTH 80
+#define KEYBOARD_BITMAP_WIDTH 45
+
 class TextKeyboard : public Keyboard {
   public:
     TextKeyboard();
@@ -53,10 +60,22 @@ class TextKeyboard : public Keyboard {
 
 #if defined(HARDWARE_TOUCH)
     bool onTouchEnd(coord_t x, coord_t y) override;
+    bool onTouchStart(coord_t x, coord_t y) override;
+    bool onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t startY, coord_t slideX, coord_t slideY) override;
 #endif
 
   protected:
+#if defined(HARDWARE_KEYS)
+    void onEvent(event_t event) override;
+#endif
+
     static TextKeyboard * _instance;
     const char * const * layout;
+  private:
+    int calculateMaxWidth();
+    int getCharWidth(const char c);
+
+    char touch_key = -128;
+    bool touched = false;
 };
 

--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -107,7 +107,6 @@ void NumberEdit::onEvent(event_t event)
         return;
 
       case EVT_KEY_BREAK(KEY_EXIT):
-        changeEnd();
 #if defined(SOFTWARE_KEYBOARD)
         Keyboard::hide();
 #endif

--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -106,6 +106,7 @@ void NumberEdit::onEvent(event_t event)
     case EVT_KEY_FIRST(KEY_EXIT):
 #if defined(SOFTWARE_KEYBOARD)
       Keyboard::hide();
+      return;
 #endif
       break;
 

--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -110,7 +110,6 @@ void NumberEdit::onEvent(event_t event)
 #if defined(SOFTWARE_KEYBOARD)
         Keyboard::hide();
 #endif
-        FormField::onEvent(event);
         break;
 
 

--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -106,6 +106,15 @@ void NumberEdit::onEvent(event_t event)
       case EVT_KEY_FIRST(KEY_EXIT):
         return;
 
+      case EVT_KEY_BREAK(KEY_EXIT):
+        changeEnd();
+#if defined(SOFTWARE_KEYBOARD)
+        Keyboard::hide();
+#endif
+        FormField::onEvent(event);
+        break;
+
+
 #if defined(HARDWARE_TOUCH)
       case EVT_VIRTUAL_KEY_PLUS:
         setValue(getValue() + getStep());

--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -103,14 +103,11 @@ void NumberEdit::onEvent(event_t event)
       }
 #endif
 
-      case EVT_KEY_FIRST(KEY_EXIT):
-        return;
-
-      case EVT_KEY_BREAK(KEY_EXIT):
+    case EVT_KEY_FIRST(KEY_EXIT):
 #if defined(SOFTWARE_KEYBOARD)
-        Keyboard::hide();
+      Keyboard::hide();
 #endif
-        break;
+      break;
 
 
 #if defined(HARDWARE_TOUCH)
@@ -174,11 +171,3 @@ bool NumberEdit::onTouchEnd(coord_t, coord_t)
 }
 #endif
 
-void NumberEdit::onFocusLost()
-{
-#if defined(SOFTWARE_KEYBOARD)
-  Keyboard::hide();
-#endif
-
-  FormField::onFocusLost();
-}

--- a/src/numberedit.h
+++ b/src/numberedit.h
@@ -67,8 +67,6 @@ class NumberEdit : public BaseNumberEdit
     bool onTouchEnd(coord_t x, coord_t y) override;
 #endif
 
-    void onFocusLost() override;
-
   protected:
     std::function<void(BitmapBuffer *, LcdFlags, int)> displayFunction;
     std::string prefix;

--- a/src/textedit.cpp
+++ b/src/textedit.cpp
@@ -170,10 +170,12 @@ void TextEdit::onEvent(event_t event)
 
       case EVT_KEY_BREAK(KEY_EXIT):
         changeEnd();
+        FormField::onEvent(event);
+        
 #if defined(SOFTWARE_KEYBOARD)
         Keyboard::hide();
 #endif
-        FormField::onEvent(event);
+        setFocus(SET_FOCUS_DEFAULT, this);
         break;
 
       case EVT_KEY_LONG(KEY_ENTER):

--- a/src/textedit.cpp
+++ b/src/textedit.cpp
@@ -170,6 +170,9 @@ void TextEdit::onEvent(event_t event)
 
       case EVT_KEY_BREAK(KEY_EXIT):
         changeEnd();
+#if defined(SOFTWARE_KEYBOARD)
+        Keyboard::hide();
+#endif
         FormField::onEvent(event);
         break;
 

--- a/src/window.h
+++ b/src/window.h
@@ -144,6 +144,11 @@ class Window
       focusHandler = std::move(handler);
     }
 
+    const std::list<Window *> getChildren()
+    {
+      return children;
+    }
+
     virtual void deleteLater(bool detach = true, bool trash = true);
 
     void clear();


### PR DESCRIPTION
Closes #116

- Centered keyboard
- Cleaned up all the magic numbers
- provide visual feedback on TouchStart
- fixes hit boxes to be halfway before the letter and halfway after. the old logic was at the first pixel of the letter to the right, making key selection haphazard.
- Fixed the bitmap position of the backspace.
- fixed issue with having edited fields be off screen
