### PR TITLE
Software keyboard - Fix crash when editing widget settings

### DIFF
--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -49,17 +49,25 @@ void Keyboard::attachKeyboard()
 // this routine finds the window that is a FormWindow.  This is the window
 // that contains all of the editable fields.  This is the window that needs
 // to be scrolled into view.
-FormWindow *Keyboard::findFormWindow()
+FormWindow *Keyboard::findFormWindow(Window *parent)
 {
-  if (fieldContainer) {
-    auto children = fieldContainer->getChildren();
-    auto k = children.begin();
-    while (k != children.end())
+  if (parent) {
+    auto children = parent->getChildren();
+    auto childIterator = children.begin();
+    while (childIterator != children.end())
     {
-      FormWindow *a = dynamic_cast<FormWindow*>(*k);
-      if (a)
-        return a;
-      k++;
+#if defined(DEBUG_WINDOWS)
+      std::string windowName;
+      Window *window = dynamic_cast<Window *>(*childIterator);
+      if (window)
+        windowName = window->getName();
+#endif
+        
+      FormWindow *formWindow = dynamic_cast<FormWindow*>(*childIterator);
+      if (formWindow)
+        return formWindow;
+
+      childIterator++;
     }
   }
 
@@ -72,11 +80,18 @@ void Keyboard::setField(FormField* newField)
 
   fieldContainer = getFieldContainer(newField);
   if (fieldContainer) {
+#if defined(DEBUG_WINDOWS)
+    auto windowName = fieldContainer->getName();
+#endif
     coord_t newHeight = LCD_H - height();
     fieldContainer->setHeight(newHeight);
 
-    fields = findFormWindow();
+    fields = findFormWindow(fieldContainer);
+
     if (fields) {
+#if defined(DEBUG_WINDOWS)
+      windowName = fields->getName();
+#endif      
       // scroll the header of the window out of view to get more space to
       // see the field being edited
       fieldContainer->setScrollPositionY(fields->top());
@@ -85,6 +100,10 @@ void Keyboard::setField(FormField* newField)
 
       coord_t offsetY = calcScrollOffsetForField(newField, fields);
       fields->setScrollPositionY(offsetY);
+    } else {
+      // TODO: what happens if field container is null. 
+      // we will need to interrogate the fieldContainer for its
+      // FormGroup.  That is really how it should work anyway.
     }
 
     invalidate();

--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -18,31 +18,6 @@
  */
 #include "keyboard_base.h"
 
-void Keyboard::hide()
-{
-  if (activeKeyboard) {
-    activeKeyboard->clearField();
-    activeKeyboard = nullptr;
-  }
-}
-
-void Keyboard::clearField()
-{
-  detach();
-  if (fields) {
-    fields->setHeight(oldHeight);
-    fields = nullptr;
-  }
-  if (fieldContainer) {
-    fieldContainer->setHeight(LCD_H - 0 - fieldContainer->top());
-    fieldContainer = nullptr;
-  }
-  if (field) {
-    field->setEditMode(false);
-    field = nullptr;
-  }
-}
-
 coord_t calcScrollOffsetForField(FormField *newField, Window *topWindow)
 {
   // now we need to calculate the offset of the field in the fields scroll container

--- a/src/keyboard_base.h
+++ b/src/keyboard_base.h
@@ -29,7 +29,31 @@ class Keyboard: public FormWindow
     {
     }
 
-    static void hide();
+    void clearField()
+    {
+      detach();
+      if (fields) { 
+        fields->setHeight(oldHeight);
+        fields = nullptr;
+      }
+      if (fieldContainer) {
+        fieldContainer->setHeight(LCD_H - 0 - fieldContainer->top());
+        fieldContainer = nullptr;
+      }
+      if (field) {
+        field->setEditMode(false);
+        field = nullptr;
+    }  
+  }
+
+    static void hide()
+    {
+      if (activeKeyboard) {
+        activeKeyboard->clearField();
+        activeKeyboard = nullptr;
+      }
+    }
+
 
   protected:
     static Keyboard * activeKeyboard;
@@ -39,7 +63,6 @@ class Keyboard: public FormWindow
     coord_t oldHeight = 0;
 
     void setField(FormField *newField);
-    void clearField();
     Window *getFieldContainer(FormField * field);
     void attachKeyboard();
     FormWindow *findFormWindow();

--- a/src/keyboard_base.h
+++ b/src/keyboard_base.h
@@ -65,6 +65,6 @@ class Keyboard: public FormWindow
     void setField(FormField *newField);
     Window *getFieldContainer(FormField * field);
     void attachKeyboard();
-    FormWindow *findFormWindow();
+    FormWindow *findFormWindow(Window *parent);
 };
 

--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -150,6 +150,16 @@ void NumberEdit::onEvent(event_t event)
   FormField::onEvent(event);
 }
 
+void NumberEdit::onFocusLost()
+{
+#if defined(SOFTWARE_KEYBOARD)
+  Keyboard::hide();
+#endif
+
+  FormField::onFocusLost();
+}
+
+
 #if defined(HARDWARE_TOUCH)
 bool NumberEdit::onTouchEnd(coord_t, coord_t)
 {

--- a/src/numberedit.h
+++ b/src/numberedit.h
@@ -62,6 +62,7 @@ class NumberEdit : public BaseNumberEdit
     }
 
     void onEvent(event_t event) override;
+    void onFocusLost() override;
 
 #if defined(HARDWARE_TOUCH)
     bool onTouchEnd(coord_t x, coord_t y) override;


### PR DESCRIPTION
Adds focusLost override to NumericKeyboard.  It now hides the keyboard when focus is lost.
