### PR TITLE
Use a virtualevent on enter so keyboard calls changeHandler() immedi…

### DIFF
--- a/src/keyboard_text.cpp
+++ b/src/keyboard_text.cpp
@@ -254,6 +254,7 @@ bool TextKeyboard::onTouchEnd(coord_t x, coord_t y)
     }
     else if (*key == KEYBOARD_ENTER[0]) {
       if (x <= KEYBOARD_ENTER_WIDTH) {
+        pushEvent(EVT_VIRTUAL_KEY(KEYBOARD_ENTER[0]));
         // enter
         hide();
         return true;

--- a/src/textedit.cpp
+++ b/src/textedit.cpp
@@ -108,6 +108,9 @@ void TextEdit::onEvent(event_t event)
         changed = true;
       }
     }
+    else if (c == (uint8_t)KEYBOARD_ENTER[0]) {
+      changeEnd();
+    }
     else if (cursorPos < length) {
       memmove(value + cursorPos + 1, value + cursorPos, length - cursorPos - 1);
       value[cursorPos++] = c;


### PR DESCRIPTION
A solution to  https://github.com/EdgeTX/edgetx/issues/714
Test case here https://github.com/EdgeTX/edgetx/issues/698

Causes the keyboards soft enter to immediately call changeHandler().

Works in all cases I have tried so far.