### PR TITLE
Fixes the defect that the software keyboard does not call onChangeEnd when hidden via touch

### DIFF
--- a/src/form.h
+++ b/src/form.h
@@ -32,6 +32,18 @@ class FormField: public Window
   public:
     FormField(Window * parent, const rect_t & rect, WindowFlags windowFlags = 0, LcdFlags textFlags = 0);
 
+    virtual void changeEnd(bool forceChanged = false)
+    {
+      if (changeHandler) {
+        changeHandler();
+      }
+    }
+    
+    void setChangeHandler(std::function<void()> handler)
+    {
+      changeHandler = std::move(handler);
+    }
+
     inline void setNextField(FormField *field)
     {
       next = field;
@@ -104,6 +116,7 @@ class FormField: public Window
     FormField * previous = nullptr;
     bool editMode = false;
     bool enabled = true;
+    std::function<void()> changeHandler = nullptr;
 };
 
 class FormGroup: public FormField

--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -37,7 +37,6 @@ coord_t calcScrollOffsetForField(FormField *newField, Window *topWindow)
 
 bool Keyboard::attachKeyboard()
 {
-  TRACE("ATTACH KEYBOARD");
   if (activeKeyboard) {
     if (activeKeyboard == this) return false;
     activeKeyboard->clearField();

--- a/src/keyboard_base.h
+++ b/src/keyboard_base.h
@@ -43,6 +43,7 @@ class Keyboard: public FormWindow
       }
       if (field) {
         field->setEditMode(false);
+        field->changeEnd();
         field = nullptr;
     }  
   }

--- a/src/textedit.h
+++ b/src/textedit.h
@@ -42,11 +42,6 @@ class TextEdit : public FormField {
     }
 #endif
 
-    void setChangeHandler(std::function<void()> handler)
-    {
-      changeHandler = std::move(handler);
-    }
-
     uint8_t getMaxLength() const
     {
       return length;
@@ -73,11 +68,10 @@ class TextEdit : public FormField {
     uint8_t length;
     const char * extra_chars;
     uint8_t cursorPos = 0;
-    std::function<void()> changeHandler = nullptr;
 
     void trim();
 
-    void changeEnd(bool forceChanged = false)
+    void changeEnd(bool forceChanged = false) override
     {
       cursorPos = 0;
       if (changed || forceChanged) {


### PR DESCRIPTION
If the keyboard is hidden via touch and not via an esc.  It changes TextEdit and FormField to move the onChange event to the base class instead of in TextEdit.  Now the keyboard calls onChange when it is hidden.

This supersedes a previous fix for this issue, which would not have completely solved the issue