### PR TITLE
Fix slide touch

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -76,9 +76,9 @@ void MainWindow::checkEvents()
       touchState.lastDeltaY += SLIDE_SPEED_REDUCTION;
     else
       touchState.lastDeltaY = 0;
-    if (touchState.lastDeltaX || touchState.lastDeltaY) {
-      onTouchSlide(touchState.x, touchState.y, touchState.startX, touchState.startY, touchState.lastDeltaX, touchState.lastDeltaY);
-    }
+
+    onTouchSlide(touchState.x, touchState.y, touchState.startX, touchState.startY, touchState.lastDeltaX, touchState.lastDeltaY);
+    slidingWindow = nullptr;
   }
 #endif
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -22,6 +22,7 @@
 
 Window * Window::focusWindow = nullptr;
 Window * Window::slidingWindow = nullptr;
+Window * Window::touchedWindow = nullptr;
 std::list<Window *> Window::trash;
 
 Window::Window(Window * parent, const rect_t & rect, WindowFlags windowFlags, LcdFlags textFlags):
@@ -411,6 +412,12 @@ bool Window::onTouchStart(coord_t x, coord_t y)
     auto child = *it;
     if (child->rect.contains(x, y)) {
       if (child->onTouchStart(x - child->rect.x + child->scrollPositionX, y - child->rect.y + child->scrollPositionY)) {
+        // remember the first window that processed the touch start event.  We will give that window
+        // the opportunity to process the touchend first, and also after a slide end so the touched window
+        // always gets a touchEnd if it processed the touch start.
+        if (touchedWindow == nullptr) {
+          touchedWindow = child;
+        }
         return true;
       }
     }
@@ -421,6 +428,26 @@ bool Window::onTouchStart(coord_t x, coord_t y)
 
 bool Window::forwardTouchEnd(coord_t x, coord_t y)
 {
+  // give the touched window the opportunity to process the touch first before it is 
+  // forwarded: See on touchstart
+  if (touchedWindow != nullptr) {
+    auto savedTouchWindow = touchedWindow;
+    touchedWindow = nullptr;
+    // transalte  x and y through the parent hierarchy
+    auto myParent = savedTouchWindow->parent;
+    while(myParent != nullptr) {
+      x = x - myParent->rect.x + myParent->scrollPositionX;
+      y = y - myParent->rect.y + myParent->scrollPositionY;
+      myParent = myParent->parent;
+    }
+
+    if (savedTouchWindow->onTouchEnd(
+          x - savedTouchWindow->rect.x + savedTouchWindow->scrollPositionX, 
+          y - savedTouchWindow->rect.y + savedTouchWindow->scrollPositionY)) {
+      return true;
+    }
+  }
+
   for (auto it = children.rbegin(); it != children.rend(); ++it) {
     auto child = *it;
     if (child->rect.contains(x, y)) {

--- a/src/window.h
+++ b/src/window.h
@@ -395,6 +395,7 @@ class Window
 
     static Window * focusWindow;
     static Window * slidingWindow;
+    static Window * touchedWindow;
     static std::list<Window *> trash;
 
     std::function<void()> closeHandler;


### PR DESCRIPTION
There has been an issue with the way touchEnd() and touchSlide works.  

First, the window that received the touchStart() should get preference to process the touchEnd() before any other windows that might have been created after the touchStart() get to process it.  This fixes an issue when you create a menu or dialog during the touchStart() processing (like for long-press bringing up a menu).  In the old code, the menu would display and immediately get dismissed, as the Modal window would get a touchEnd() with touch coordinates outside of the Modal Dialog window's rectangle. 
Now forwardTouchEnd() gives preference to the window that received the touchStart().  If that window doesn't process the event it resumes normal forwarding of the event.  It does not seem to break anything that I can tell, but it is a core change!

The second issue is with windows that want to process touchSlide() but do not themselves ever have their scroll position change.  This is the way the new ColorEditor works.  It uses the touch events to move things on the window dynamically.  In MainWindow() checkEvents() it was suppressing the final touch end event if there was no delta x or y, which in the case of the ColorEditor is always true (as it does not scroll).  Now, this code always passes the end event.  This had a knock-on effect of the onTouchSlide() method continuously being called as for some reason the hardware continues to generate this event (at least on simu).  So now it always calls touchSlide() when there is a touch end event, but resets the slidingWindow to nullptr so that onTouchEnd() does not continuously get called.

small coding changes but big potential impact.  This is a good change to put in the system and do not appear to break anything