### PR TITLE
If scroll value out of range, set min or max number_edit value

### DIFF
--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -82,6 +82,7 @@ void NumberEdit::onEvent(event_t event)
           onKeyPress();
         }
         else {
+          setValue(vmax);
           onKeyError();
         }
         return;
@@ -97,6 +98,7 @@ void NumberEdit::onEvent(event_t event)
           onKeyPress();
         }
         else {
+          setValue(vmin);
           onKeyError();
         }
         return;


### PR DESCRIPTION
Depending on the direction of scroll, set either the min or max value when the rotary_encoder value is out of range.

I _think_ NumberEditis the only UI element needing to be tweaked to resolve this?

Resolves https://github.com/EdgeTX/edgetx/issues/399