### PR TITLE
Let buttons catch touchStart

### DIFF
--- a/src/button.cpp
+++ b/src/button.cpp
@@ -48,6 +48,14 @@ void Button::onEvent(event_t event)
 #endif
 
 #if defined(HARDWARE_TOUCH)
+bool Button::onTouchStart(coord_t x, coord_t y)
+{
+  Window::onTouchStart(x, y);
+  return true;
+}
+#endif
+
+#if defined(HARDWARE_TOUCH)
 bool Button::onTouchEnd(coord_t x, coord_t y)
 {
   if (enabled) {

--- a/src/button.h
+++ b/src/button.h
@@ -74,6 +74,7 @@ class Button: public FormField
 #endif
 
 #if defined(HARDWARE_TOUCH)
+    bool onTouchStart(coord_t x, coord_t y) override;
     bool onTouchEnd(coord_t x, coord_t y) override;
 #endif
 


### PR DESCRIPTION
Resolves https://github.com/EdgeTX/edgetx/issues/1087

Thanks @kevinkoenig for the explanation for this ;)

`simu` for TX16S seems a little off on this for the top bar icons in say model setup, but actual hardware seems fine. Will try and look into that a bit further first. 