### PR TITLE
Fix repeated touch events

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -158,7 +158,7 @@ void MainWindow::checkEvents()
     onTouchEnd(touchState.startX + scrollPositionX, touchState.startY + scrollPositionY);
     touchState.event = TE_NONE;
   }
-  if(touchState.event != TE_SLIDE && touchState.event != TE_SLIDE_END) {
+  if(touchState.event != TE_SLIDE_END) {
     touchState.event = TE_NONE;
   } 
 #endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -158,6 +158,9 @@ void MainWindow::checkEvents()
     onTouchEnd(touchState.startX + scrollPositionX, touchState.startY + scrollPositionY);
     touchState.event = TE_NONE;
   }
+  if(touchState.event != TE_SLIDE && touchState.event != TE_SLIDE_END) {
+    touchState.event = TE_NONE;
+  } 
 #endif
 
   Window::checkEvents();


### PR DESCRIPTION
Touch events are sometimes handled multiple times. This prevents it. The problem was found during debugging of the overly sensitive touch screen on NV14.