### PR TITLE
fix: the check to prevent out of screenbuffer drawing did not work

### DIFF
--- a/src/bitmapbuffer.h
+++ b/src/bitmapbuffer.h
@@ -403,7 +403,7 @@ class BitmapBuffer: public BitmapBufferBase<pixel_t>
 
     inline void drawPixel(pixel_t * p, pixel_t value)
     {
-      if (data && (data <= p || p < data_end)) {
+      if (data && (data <= p && p < data_end)) {
         *p = value;
       }
 #if defined(DEBUG)


### PR DESCRIPTION
this fixes the not work out of screenbuffer drawing check.
This prevents the crash from EdgeTX #2124 and maybe more crashes, but does not solve the underlying problem