### PR TITLE
Invalid index in Menus vector<> lines

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -35,6 +35,8 @@ void MenuBody::onDrawBegin(uint16_t row, uint16_t col, lv_obj_draw_part_dsc_t* d
 
 void MenuBody::onDrawEnd(uint16_t row, uint16_t col, lv_obj_draw_part_dsc_t* dsc)
 {
+  if(row >= lines.size())  return;
+
   lv_obj_t* icon = lines[row].getIcon();
   if (icon) {
     lv_draw_img_dsc_t img_dsc;


### PR DESCRIPTION
Method can get called before std::vector<MenuLines> lines has data, resulting in a crash when it tries to use the invalid index.

Issue showed up when in the Bluetooth Discover menu when a line was added in checkEvents. Not sure if it will elsewhere too.