### PR TITLE
Textedit fixes

### DIFF
--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -104,13 +104,19 @@ void Keyboard::clearField()
   if (field) {
     // restore field's group
     auto obj = field->getLvObj();
-    lv_obj_remove_event_cb(obj, field_focus_leave);
-    lv_group_t* g = (lv_group_t*)lv_obj_get_group(obj);
-    if (g) _assign_lv_group(g);
+    if (obj) {
+      lv_obj_remove_event_cb(obj, field_focus_leave);
+    }
     
     field->setEditMode(false);
     field->changeEnd();
     field = nullptr;
+
+    if (fieldGroup) {
+      _assign_lv_group(fieldGroup);
+      lv_group_set_editing(fieldGroup, false);
+      fieldGroup = nullptr;
+    }
   }
 }
 
@@ -165,6 +171,7 @@ void Keyboard::setField(FormField* newField)
       _assign_lv_group(group);
       
       field = newField;
+      fieldGroup = (lv_group_t*)lv_obj_get_group(obj);
     }
   }
 }

--- a/src/keyboard_base.cpp
+++ b/src/keyboard_base.cpp
@@ -27,7 +27,6 @@ static void keyboard_event_cb(lv_event_t * e)
 {
   auto code = lv_event_get_code(e);
   if (code == LV_EVENT_READY) {
-    pushEvent(EVT_VIRTUAL_KEY('\n'));
     Keyboard::hide();
   } else if (code == LV_EVENT_CANCEL) {
     Keyboard::hide();

--- a/src/keyboard_base.h
+++ b/src/keyboard_base.h
@@ -40,6 +40,7 @@ class Keyboard : public Window
 
   FormField* field = nullptr;
   Window* fieldContainer = nullptr;
+  lv_group_t* fieldGroup = nullptr;
   lv_coord_t scroll_pos = 0;
 
   void setField(FormField* newField);

--- a/src/textedit.cpp
+++ b/src/textedit.cpp
@@ -41,15 +41,12 @@
 #endif
 
 TextEdit::TextEdit(Window *parent, const rect_t &rect, char *value,
-                   uint8_t length, LcdFlags windowFlags,
-                   const char *_extra_chars) :
+                   uint8_t length, LcdFlags windowFlags) :
     FormField(parent, rect, windowFlags, 0,
               field_edit_create),
     value(value),
     length(length)
 {
-  extra_chars = (_extra_chars) ? _extra_chars : extra_chars_default;
-
   // properties
   lv_obj_set_scrollbar_mode(lvobj, LV_SCROLLBAR_MODE_OFF);
   lv_textarea_set_password_mode(lvobj, false);
@@ -72,13 +69,6 @@ void TextEdit::update()
   lv_textarea_set_text(lvobj, txt.c_str());  
 }
 
-void TextEdit::setCursorPos(int cursorPos)
-{
-  this->cursorPos = cursorPos;
-  if (lvobj != nullptr)
-    lv_textarea_set_cursor_pos(lvobj, cursorPos);
-}
-
 void TextEdit::trim()
 {
   for (int i = length - 1; i >= 0; i--) {
@@ -89,134 +79,25 @@ void TextEdit::trim()
   }
 }
 
-void TextEdit::onEvent(event_t event)
+void TextEdit::changeEnd(bool forceChanged)
 {
-  TRACE_WINDOWS("%s received event 0x%X", getWindowDebugString().c_str(), event);
+  if (lvobj == nullptr) return;
 
-  if (IS_VIRTUAL_KEY_EVENT(event)) {
-    uint8_t c = event & 0xFF;
-    if (c == LV_KEY_ENTER) {
-      changeEnd();
-    }
+  bool changed = false;
+  auto text = lv_textarea_get_text(lvobj);
+  if (strncmp(value, text, length) != 0) {
+    changed = true;
   }
 
-// #if defined(HARDWARE_KEYS)
-//   if (editMode) {
-//     int c = value[cursorPos];
-//     int v = c;
-
-//     switch (event) {
-//       case EVT_ROTARY_RIGHT:
-//         for (int i = 0; i < ROTARY_ENCODER_SPEED(); i++) {
-//           v = getNextChar(v);
-//         }
-//         break;
-
-//       case EVT_ROTARY_LEFT:
-//         for (int i = 0; i < ROTARY_ENCODER_SPEED(); i++) {
-//           v = getPreviousChar(v);
-//         }
-//         break;
-
-//       case EVT_KEY_BREAK(KEY_LEFT):
-//         if (cursorPos > 0) {
-//           setCursorPos(cursorPos - 1);
-//         }
-//         break;
-
-//       case EVT_KEY_BREAK(KEY_RIGHT):
-//         if (cursorPos < length - 1 && value[cursorPos + 1] != '\0') {
-//           setCursorPos(cursorPos + 1);
-//         }
-//         break;
-
-//       case EVT_KEY_BREAK(KEY_ENTER):
-//         if (cursorPos < length - 1) {
-//           if (value[cursorPos] == '\0') {
-//             value[cursorPos] = ' ';
-//             changed = true;
-//           }
-//           cursorPos++;
-//           if (value[cursorPos] == '\0') {
-//             value[cursorPos] = ' ';
-//             changed = true;
-//           }
-//           update();
-//           setCursorPos(cursorPos);
-//         }
-//         else {
-//           changeEnd();
-//           FormField::onEvent(event);
-//         }
-//         break;
-
-//       case EVT_KEY_LONG(KEY_ENTER):
-//       {
-//         killEvents(event);
-//         auto menu = new Menu(this);
-//         menu->setTitle(STR_EDIT);
-// #if defined(CLIPBOARD)
-//         menu->addLine(STR_COPY, [=] {
-//           clipboard.write((uint8_t *)value, length, Clipboard::CONTENT_TEXT);
-//         });
-//         if (clipboard.contentType == Clipboard::CONTENT_TEXT) {
-//           menu->addLine(STR_PASTE, [=] {
-//             clipboard.read((uint8_t *)value, length);
-//             changeEnd(true);
-//           });
-//         }
-// #endif
-//         menu->addLine(STR_CLEAR, [=] {
-//           memset(value, 0, length);
-//           changeEnd(true);
-//         });
-//         break;
-//       }
-
-//       case EVT_KEY_BREAK(KEY_UP):
-//         v = toggleCase(v);
-//         break;
-
-//       case EVT_KEY_LONG(KEY_LEFT):
-//       case EVT_KEY_LONG(KEY_RIGHT):
-//         v = toggleCase(v);
-//         if (event == EVT_KEY_LONG(KEY_LEFT)) {
-//           killEvents(KEY_LEFT);
-//         }
-//         break;
-
-//       case EVT_KEY_BREAK(KEY_PGDN):
-//         if (cursorPos < length) {
-//           memmove(&value[cursorPos], &value[cursorPos + 1], length - cursorPos - 1);
-//           value[length - 1] = '\0';
-//           changed = true;
-//           if (cursorPos > 0 && value[cursorPos] == '\0') {
-//             cursorPos = cursorPos - 1;
-//           }
-//           update();
-//           setCursorPos(cursorPos);
-//         }
-//         break;
-//     }
-
-//     if (c != v) {
-//       // TRACE("value[%d] = %d", cursorPos, v);
-//       value[cursorPos] = v;
-//       update();
-//       setCursorPos(cursorPos);
-//       changed = true;
-//     }
-//   }
-//   else {
-//     FormField::onEvent(event);
-//     setCursorPos(0);
-//   }
-// #endif
+  if (changed || forceChanged) {
+    strncpy(value, text, length);
+    trim();
+    FormField::changeEnd();
+  }
 }
 
 void TextEdit::onClicked()
 {
-  cursorPos = lv_textarea_get_cursor_pos(lvobj);
   TextKeyboard::show(this);
 }
 

--- a/src/textedit.h
+++ b/src/textedit.h
@@ -21,121 +21,31 @@
 
 #include "form.h"
 
-const char extra_chars_default[] = ":;<=>";
+class TextEdit : public FormField
+{
 
-class TextEdit : public FormField {
-  friend class TextKeyboard;
-
-  public:
-    TextEdit(Window* parent, const rect_t& rect, char* value, uint8_t length,
-             LcdFlags windowFlags = 0, const char* _extra_chars = nullptr);
+ public:
+  TextEdit(Window* parent, const rect_t& rect, char* value, uint8_t length,
+           LcdFlags windowFlags = 0);
 
 #if defined(DEBUG_WINDOWS)
-    std::string getName() const override
-    {
-      return "TextEdit";
-    }
+  std::string getName() const override { return "TextEdit"; }
 #endif
 
-    uint8_t getMaxLength() const
-    {
-      return length;
-    }
+  uint8_t getMaxLength() const { return length; }
+  char* getData() const { return value; }
 
-    char * getData() const
-    {
-      return value;
-    }
+  void update();
 
-    void update();
+ protected:
+  static void event_cb(lv_event_t* e);
   
-    void onEvent(event_t event) override;
-    void onClicked() override;
+  char* value;
+  uint8_t length;
 
-    void onFocusLost() override;
+  void trim();
 
-    virtual void paint(BitmapBuffer* dc) override {};
-
-    void setCursorPos(int cursorPos);
-
-  protected:
-    char * value;
-    bool changed = false;
-    uint8_t length;
-    const char * extra_chars;
-    uint8_t cursorPos = 0;
-
-    void trim();
-
-    void changeEnd(bool forceChanged = false) override
-    {
-      if (lvobj != nullptr)
-        strncpy(value, lv_textarea_get_text(lvobj), length);
-
-      setCursorPos(0);
-      if (changed || forceChanged) {
-        changed = false;
-        trim();
-        if (changeHandler) {
-          changeHandler();
-        }
-      }
-    }
-
-    uint8_t getNextChar(uint8_t c)
-    {
-      if (c == ' ' || c == '\0')
-        return 'A';
-      else if (c >= 'A' && c < 'Z')
-        return c + 1;
-      else if (c == 'Z')
-        return 'a';
-      else if (c >= 'a' && c < 'z')
-        return c + 1;
-      else if (c == 'z')
-        return '0';
-      else if (c >= '0' && c < '9')
-        return c + 1;
-      else if (c == '9')
-        return extra_chars[0];
-      else {
-        for (uint8_t n = 0; n < strlen(extra_chars) - 1; n++)
-          if (c == extra_chars[n]) return extra_chars[n + 1];
-        return ' ';
-      }
-    }
-
-    uint8_t getPreviousChar(uint8_t c)
-    {
-      if (c == ' ' || c == '\0')
-        return extra_chars[strlen(extra_chars) - 1];
-      else if (c == 'A')
-        return ' ';
-      else if (c > 'A' && c <= 'Z')
-        return c - 1;
-      else if (c == 'a')
-        return 'Z';
-      else if (c > 'a' && c <= 'z')
-        return c - 1;
-      else if (c == '0')
-        return 'z';
-      else if (c > '0' && c <= '9')
-        return c - 1;
-      else {
-        for (uint8_t n = 1; n < strlen(extra_chars); n++)
-          if (c == extra_chars[n]) return extra_chars[n - 1];
-        return '9';
-      }
-    }
-
-    static uint8_t toggleCase(uint8_t c)
-    {
-      if (c >= 'A' && c <= 'Z')
-        return c + 32; // tolower
-      else if (c >= 'a' && c <= 'z')
-        return c - 32; // toupper
-      else
-        return c;
-    }
+  void changeEnd(bool forceChanged = false) override;
+  void onClicked() override;
+  void onFocusLost() override;
 };
-

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -328,8 +328,9 @@ void Window::deleteLater(bool detach, bool trash)
   deleteChildren();
 
   if (lvobj != nullptr) {
-    lv_obj_del(lvobj);
+    auto obj = lvobj;
     lvobj = nullptr;
+    lv_obj_del(obj);
   }
 }
 


### PR DESCRIPTION
This PR is required for EdgeTX/edgetx#2192.

As all radios (with or without touch sensor) now use the visual keyboard, most of the event handling can be removed from `TextEdit`. This PR also fixes an issue introduced with 40d6ae5ee8 (keys not working when a text edit is focused). 