### PR TITLE
fix(NumberEdit): do not call setValue() in constructor, use update() …

### DIFF
--- a/src/numberedit.cpp
+++ b/src/numberedit.cpp
@@ -54,10 +54,7 @@ NumberEdit::NumberEdit(Window* parent, const rect_t& rect, int vmin, int vmax,
   lv_textarea_set_one_line(lvobj, true);
   lv_obj_add_event_cb(lvobj, numberedit_cb, LV_EVENT_KEY, this);
 
-  if (_getValue) {
-    auto value = _getValue();
-    this->setValue(value);
-  }
+  update();
 }
 
 void NumberEdit::onEvent(event_t event)


### PR DESCRIPTION
…instead

This avoids writing a value when it is not necessary. All that is needed is to update the internal value and set the field string.