### PR TITLE
Speed up the initial menu filling

### DIFF
--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -209,20 +209,23 @@ void Choice::fillMenu(Menu *menu, const FilterFct& filter)
   menu->removeLines();
   auto value = _getValue();
   
-  int count = 0;
-  for (int i = vmin; i <= vmax; ++i) {
-    if (filter && !filter(i)) continue;
-    if (isValueAvailable && !isValueAvailable(i)) continue;
-    if (textHandler) {
-      menu->addLine(textHandler(i), [=]() { setValue(i); });
-    } else if (unsigned(i - vmin) < values.size()) {
-      menu->addLine(values[i - vmin], [=]() { setValue(i); });
-    } else {
-      menu->addLine(std::to_string(i), [=]() { setValue(i); });
-    }
-    if (value == i) { menu->select(count); }
-    ++count;
-  }
+  menu->addLines(vmin, vmax, [=](int i) {
+      Menu::MenuLineDesc desc;
+      if (textHandler) {
+        desc.text = textHandler(i);
+      } else if (unsigned(i - vmin) < values.size()) {
+        desc.text = values[i - vmin];
+      } else {
+        desc.text = std::to_string(i);
+      }
+      desc.onPress = [=]() { setValue(i); };
+      desc.selected = (value == i);
+      return desc;
+    },
+    [=](int i) {
+      return !((filter && !filter(i))
+               || (isValueAvailable && !isValueAvailable(i)));
+    });
 }
 
 void Choice::openMenu()

--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -209,23 +209,23 @@ void Choice::fillMenu(Menu *menu, const FilterFct& filter)
   menu->removeLines();
   auto value = _getValue();
   
-  menu->addLines(vmin, vmax, [=](int i) {
-      Menu::MenuLineDesc desc;
-      if (textHandler) {
-        desc.text = textHandler(i);
-      } else if (unsigned(i - vmin) < values.size()) {
-        desc.text = values[i - vmin];
-      } else {
-        desc.text = std::to_string(i);
-      }
-      desc.onPress = [=]() { setValue(i); };
-      desc.selected = (value == i);
-      return desc;
-    },
-    [=](int i) {
-      return !((filter && !filter(i))
-               || (isValueAvailable && !isValueAvailable(i)));
-    });
+  int count = 0;
+  int selectedIx = -1;
+  for (int i = vmin; i <= vmax; ++i) {
+    if (filter && !filter(i)) continue;
+    if (isValueAvailable && !isValueAvailable(i)) continue;
+    if (textHandler) {
+      menu->addLineBuffered(textHandler(i), [=]() { setValue(i); });
+    } else if (unsigned(i - vmin) < values.size()) {
+      menu->addLineBuffered(values[i - vmin], [=]() { setValue(i); });
+    } else {
+      menu->addLineBuffered(std::to_string(i), [=]() { setValue(i); });
+    }
+    if (value == i) { selectedIx = count; }
+    ++count;
+  }
+  menu->updateLines();
+  if (selectedIx >= 0) { menu->select(selectedIx); }
 }
 
 void Choice::openMenu()

--- a/src/filechoice.cpp
+++ b/src/filechoice.cpp
@@ -97,19 +97,27 @@ bool FileChoice::openMenu()
       files.push_front("");
 
       auto menu = new Menu(this);
+      int count = 0;
+      int current = -1;
       std::string value = getValue();
-      std::vector<std::string> filesv(files.begin(), files.end());
-      menu->addLines(0, filesv.size() - 1, [=](int i) {
-        std::string file = filesv[i];
-        Menu::MenuLineDesc desc;
-        desc.text = file;
-        desc.onPress = [=]() {
-          setValue(file);
-          lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
-        };
-        desc.selected = (value.compare(file) == 0);
-        return desc;
-      });
+      for (const auto &file : files) {
+        menu->addLineBuffered(file, [=]() {
+            setValue(file);
+            lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
+        });
+        // TRACE("%s %d %s %d", value.c_str(), value.size(), file.c_str(),
+        // file.size());
+        if (value.compare(file) == 0) {
+          // TRACE("OK");
+          current = count;
+        }
+        ++count;
+      }
+      menu->updateLines();
+
+      if (current >= 0) {
+        menu->select(current);
+      }
 
       menu->setCloseHandler([=]() {
         editMode = false;

--- a/src/filechoice.cpp
+++ b/src/filechoice.cpp
@@ -97,28 +97,20 @@ bool FileChoice::openMenu()
       files.push_front("");
 
       auto menu = new Menu(this);
-      menu->setLineCount(files.size());
-      int count = 0;
-      int current = -1;
       std::string value = getValue();
-      for (const auto &file : files) {
-        menu->addLine(file, [=]() {
-            setValue(file);
-            lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
-        }, nullptr, false);
-        // TRACE("%s %d %s %d", value.c_str(), value.size(), file.c_str(),
-        // file.size());
-        if (value.compare(file) == 0) {
-          // TRACE("OK");
-          current = count;
-        }
-        ++count;
-      }
-      menu->updatePosition();
-
-      if (current >= 0) {
-        menu->select(current);
-      }
+      std::vector<std::string> filesv;
+      std::copy(files.begin(), files.end(), std::back_inserter(filesv));
+      menu->addLines(0, filesv.size() - 1, [=](int i, std::string& text,
+                     std::function<void()>& onPress, std::function<bool()>& isChecked,
+                     bool& selected) {
+        std::string file = filesv[i];
+        text = file;
+        onPress = [=]() {
+          setValue(file);
+          lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
+        };
+        selected = (value.compare(file) == 0);
+      });
 
       menu->setCloseHandler([=]() {
         editMode = false;

--- a/src/filechoice.cpp
+++ b/src/filechoice.cpp
@@ -97,6 +97,7 @@ bool FileChoice::openMenu()
       files.push_front("");
 
       auto menu = new Menu(this);
+      menu->setLineCount(files.size());
       int count = 0;
       int current = -1;
       std::string value = getValue();
@@ -104,7 +105,7 @@ bool FileChoice::openMenu()
         menu->addLine(file, [=]() {
             setValue(file);
             lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
-        });
+        }, nullptr, false);
         // TRACE("%s %d %s %d", value.c_str(), value.size(), file.c_str(),
         // file.size());
         if (value.compare(file) == 0) {
@@ -113,6 +114,7 @@ bool FileChoice::openMenu()
         }
         ++count;
       }
+      menu->updatePosition();
 
       if (current >= 0) {
         menu->select(current);

--- a/src/filechoice.cpp
+++ b/src/filechoice.cpp
@@ -98,18 +98,17 @@ bool FileChoice::openMenu()
 
       auto menu = new Menu(this);
       std::string value = getValue();
-      std::vector<std::string> filesv;
-      std::copy(files.begin(), files.end(), std::back_inserter(filesv));
-      menu->addLines(0, filesv.size() - 1, [=](int i, std::string& text,
-                     std::function<void()>& onPress, std::function<bool()>& isChecked,
-                     bool& selected) {
+      std::vector<std::string> filesv(files.begin(), files.end());
+      menu->addLines(0, filesv.size() - 1, [=](int i) {
         std::string file = filesv[i];
-        text = file;
-        onPress = [=]() {
+        Menu::MenuLineDesc desc;
+        desc.text = file;
+        desc.onPress = [=]() {
           setValue(file);
           lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
         };
-        selected = (value.compare(file) == 0);
+        desc.selected = (value.compare(file) == 0);
+        return desc;
       });
 
       menu->setCloseHandler([=]() {

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -97,6 +97,11 @@ MenuBody::MenuBody(Window * parent, const rect_t & rect):
   }
 }
 
+void MenuBody::setLineCount(uint16_t rows)
+{
+  setRowCount(rows);
+}
+
 void MenuBody::addLine(const std::string &text, std::function<void()> onPress,
                        std::function<bool()> isChecked)
 {
@@ -312,19 +317,27 @@ void Menu::setTitle(std::string text)
   updatePosition();
 }
 
+void Menu::setLineCount(uint16_t rows)
+{
+  content->body.setLineCount(rows);
+  updatePosition();
+}
+
 void Menu::addLine(const std::string &text, std::function<void()> onPress,
-                   std::function<bool()> isChecked)
+                   std::function<bool()> isChecked, 
+                   bool updatePos)
 {
   content->body.addLine(text, std::move(onPress), std::move(isChecked));
-  updatePosition();
+  if(updatePos) updatePosition();
 }
 
 void Menu::addLine(const uint8_t *icon_mask, const std::string &text,
                    std::function<void()> onPress,
-                   std::function<bool()> isChecked)
+                   std::function<bool()> isChecked, 
+                   bool updatePos)
 {
   content->body.addLine(icon_mask, text, std::move(onPress), std::move(isChecked));
-  updatePosition();
+  if(updatePos) updatePosition();
 }
 
 void Menu::removeLines()

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -328,7 +328,9 @@ void Menu::addLine(const std::string &text, std::function<void()> onPress,
                    bool updatePos)
 {
   content->body.addLine(text, std::move(onPress), std::move(isChecked));
-  if(updatePos) updatePosition();
+  if(updatePos) {
+    updatePosition();
+  }
 }
 
 void Menu::addLine(const uint8_t *icon_mask, const std::string &text,
@@ -337,7 +339,9 @@ void Menu::addLine(const uint8_t *icon_mask, const std::string &text,
                    bool updatePos)
 {
   content->body.addLine(icon_mask, text, std::move(onPress), std::move(isChecked));
-  if(updatePos) updatePosition();
+  if(updatePos) {
+    updatePosition();
+  }
 }
 
 void Menu::removeLines()

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -97,34 +97,42 @@ MenuBody::MenuBody(Window * parent, const rect_t & rect):
   }
 }
 
-void MenuBody::addLineCount(uint16_t rows)
-{
-  setRowCount(lines.size() + rows);
-}
-
 void MenuBody::addLine(const std::string &text, std::function<void()> onPress,
-                       std::function<bool()> isChecked)
+                       std::function<bool()> isChecked, bool update)
 {
-  lines.emplace_back(std::move(onPress), std::move(isChecked), nullptr);
+  lines.emplace_back(text, std::move(onPress), std::move(isChecked), nullptr);
 
-  auto idx = lines.size() - 1;
-  lv_table_set_cell_value(lvobj, idx, 0, text.c_str());
+  if (update) {
+    auto idx = lines.size() - 1;
+    lv_table_set_cell_value(lvobj, idx, 0, text.c_str());
+  }
 }
 
 void MenuBody::addLine(const uint8_t *icon_mask, const std::string &text,
                        std::function<void()> onPress,
-                       std::function<bool()> isChecked)
+                       std::function<bool()> isChecked,
+                       bool update)
 {
   lv_obj_t* canvas = lv_canvas_create(nullptr);
-  lines.emplace_back(std::move(onPress), std::move(isChecked), canvas);
+  lines.emplace_back(text, std::move(onPress), std::move(isChecked), canvas);
 
   lv_coord_t w = *((uint16_t *)icon_mask);
   lv_coord_t h = *(((uint16_t *)icon_mask)+1);
   void* buf = (void*)(icon_mask + 4);
   lv_canvas_set_buffer(canvas, buf, w, h, LV_IMG_CF_ALPHA_8BIT);
 
-  auto idx = lines.size() - 1;
-  lv_table_set_cell_value_fmt(lvobj, idx, 0, text.c_str());
+  if (update) {
+    auto idx = lines.size() - 1;
+    lv_table_set_cell_value_fmt(lvobj, idx, 0, text.c_str());
+  }
+}
+
+void MenuBody::updateLines()
+{
+  setRowCount(lines.size());
+  for(unsigned int idx = 0; idx < lines.size(); idx++) {
+    lv_table_set_cell_value_fmt(lvobj, idx, 0, lines[idx].text.c_str());
+  }
 }
 
 void MenuBody::removeLines()
@@ -332,41 +340,23 @@ void Menu::addLine(const uint8_t *icon_mask, const std::string &text,
   updatePosition();
 }
 
-void Menu::addLines(int vmin, int vmax, std::function<MenuLineDesc(int)> lineFn,
-                    std::function<bool(int)> isValid, int step)
+void Menu::addLineBuffered(const std::string &text, std::function<void()> onPress,
+                   std::function<bool()> isChecked)
 {
-  // count lines
-  int count = 0;
-  for (int i = vmin; i <= vmax; i += step) {
-    if(!isValid || isValid(i)) {
-      count++;
-    }
-  }
-  // preset line count
-  content->body.addLineCount(count);
+  content->body.addLine(text, std::move(onPress), std::move(isChecked), false);
+}
 
-  // set the lines
-  int selectedIx = -1;
-  count = 0;
-  for (int i = vmin; i <= vmax; i += step) {
-    if(isValid && !isValid(i)) continue;
+void Menu::addLineBuffered(const uint8_t *icon_mask, const std::string &text,
+                   std::function<void()> onPress,
+                   std::function<bool()> isChecked)
+{
+  content->body.addLine(icon_mask, text, std::move(onPress), std::move(isChecked), false);
+}
 
-    MenuLineDesc desc = lineFn(i);
-    if(desc.icon_mask) {
-      content->body.addLine(desc.icon_mask, desc.text, std::move(desc.onPress), std::move(desc.isChecked));
-    } else {
-      content->body.addLine(desc.text, std::move(desc.onPress), std::move(desc.isChecked));
-    }
-    if(desc.selected) {
-      selectedIx = count;
-    }
-    count++;
-  }
+void Menu::updateLines()
+{
+  content->body.updateLines();
   updatePosition();
-
-  if(selectedIx >= 0) {
-    select(selectedIx);
-  }
 }
 
 void Menu::removeLines()

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -332,7 +332,8 @@ void Menu::addLine(const uint8_t *icon_mask, const std::string &text,
   updatePosition();
 }
 
-void Menu::addLines(int vmin, int vmax, lineDataHandler lineFn, std::function<bool(int)> isValid, int step)
+void Menu::addLines(int vmin, int vmax, std::function<MenuLineDesc(int)> lineFn,
+                    std::function<bool(int)> isValid, int step)
 {
   // count lines
   int count = 0;
@@ -349,13 +350,13 @@ void Menu::addLines(int vmin, int vmax, lineDataHandler lineFn, std::function<bo
   for (int i = vmin; i <= vmax; i += step) {
     if(isValid && !isValid(i)) continue;
 
-    std::string text;
-    std::function<void()> onPress = nullptr;
-    std::function<bool()> isChecked = nullptr;
-    bool selected = false;
-    lineFn(i, text, onPress, isChecked, selected);
-    content->body.addLine(text, std::move(onPress), std::move(isChecked));
-    if(selected) {
+    MenuLineDesc desc = lineFn(i);
+    if(desc.icon_mask) {
+      content->body.addLine(desc.icon_mask, desc.text, std::move(desc.onPress), std::move(desc.isChecked));
+    } else {
+      content->body.addLine(desc.text, std::move(desc.onPress), std::move(desc.isChecked));
+    }
+    if(desc.selected) {
       selectedIx = i;
     }
   }
@@ -365,42 +366,6 @@ void Menu::addLines(int vmin, int vmax, lineDataHandler lineFn, std::function<bo
     select(selectedIx);
   }
 }
-
-void Menu::addLines(int vmin, int vmax, ilineDataHandler lineFn, std::function<bool(int)> isValid, int step)
-{
-  // count lines
-  int count = 0;
-  for (int i = vmin; i <= vmax; i += step) {
-    if(!isValid || isValid(i)) {
-      count++;
-    }
-  }
-  // preset line count
-  content->body.addLineCount(count);
-
-  // set the lines
-  int selectedIx = -1;
-  for (int i = vmin; i <= vmax; i += step) {
-    if(isValid && !isValid(i)) continue;
-
-    uint8_t* icon_mask = nullptr;
-    std::string text;
-    std::function<void()> onPress = nullptr;
-    std::function<bool()> isChecked = nullptr;
-    bool selected = false;
-    lineFn(i, icon_mask, text, onPress, isChecked, selected);
-    content->body.addLine(icon_mask, text, std::move(onPress), std::move(isChecked));
-    if(selected) {
-      selectedIx = i;
-    }
-  }
-  updatePosition();
-
-  if(selectedIx >= 0) {
-    select(selectedIx);
-  }
-}
-
 
 void Menu::removeLines()
 {

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -347,6 +347,7 @@ void Menu::addLines(int vmin, int vmax, std::function<MenuLineDesc(int)> lineFn,
 
   // set the lines
   int selectedIx = -1;
+  count = 0;
   for (int i = vmin; i <= vmax; i += step) {
     if(isValid && !isValid(i)) continue;
 
@@ -357,8 +358,9 @@ void Menu::addLines(int vmin, int vmax, std::function<MenuLineDesc(int)> lineFn,
       content->body.addLine(desc.text, std::move(desc.onPress), std::move(desc.isChecked));
     }
     if(desc.selected) {
-      selectedIx = i;
+      selectedIx = count;
     }
+    count++;
   }
   updatePosition();
 

--- a/src/menu.h
+++ b/src/menu.h
@@ -53,9 +53,9 @@ class MenuBody: public TableField
     friend class MenuBody;
 
    public:
-    MenuLine(std::function<void()> onPress, std::function<bool()> isChecked,
+    MenuLine(const std::string& text, std::function<void()> onPress, std::function<bool()> isChecked,
              lv_obj_t *icon) :
-        onPress(std::move(onPress)), isChecked(std::move(isChecked)), icon(icon)
+        text(text), onPress(std::move(onPress)), isChecked(std::move(isChecked)), icon(icon)
     {
     }
 
@@ -65,6 +65,7 @@ class MenuBody: public TableField
     lv_obj_t* getIcon() { return icon.get(); }
     
    protected:
+    std::string text;
     std::function<void()> onPress;
     std::function<bool()> isChecked;
     std::unique_ptr<lv_obj_t, lvobj_delete> icon;
@@ -95,13 +96,15 @@ class MenuBody: public TableField
     void onEvent(event_t event) override;
     void onCancel() override;
 
-    void addLineCount(uint16_t rows);
     void addLine(const std::string &text, std::function<void()> onPress,
-                 std::function<bool()> isChecked);
+                 std::function<bool()> isChecked, bool update = true);
 
     void addLine(const uint8_t *icon_mask, const std::string &text,
                  std::function<void()> onPress,
-                 std::function<bool()> isChecked);
+                 std::function<bool()> isChecked,
+                 bool update = true);
+
+    void updateLines();
 
     void removeLines();
 
@@ -156,26 +159,6 @@ class Menu: public ModalWindow
   friend class MenuBody;
 
   public:
-    class MenuLineDesc
-    {
-    public:
-      MenuLineDesc()
-      {
-        icon_mask = nullptr;
-        onPress = nullptr;
-        isChecked = nullptr;
-        selected = false;
-      }
-
-    public:
-      uint8_t *icon_mask;
-      std::string text;
-      std::function<void()> onPress;
-      std::function<bool()> isChecked;
-      bool selected;
-    };
-
-  public:
     explicit Menu(Window * parent, bool multiple = false);
 
 #if defined(DEBUG_WINDOWS)
@@ -206,8 +189,14 @@ class Menu: public ModalWindow
                  std::function<void()> onPress,
                  std::function<bool()> isChecked = nullptr);
 
-    void addLines(int vmin, int vmax, std::function<MenuLineDesc(int)> lineFn,
-                  std::function<bool(int)> isValid = nullptr, int step = 1);
+    void addLineBuffered(const std::string &text, std::function<void()> onPress,
+                 std::function<bool()> isChecked = nullptr);
+
+    void addLineBuffered(const uint8_t *icon_mask, const std::string &text,
+                 std::function<void()> onPress,
+                 std::function<bool()> isChecked = nullptr);
+
+    void updateLines();
 
     void addSeparator();
 

--- a/src/menu.h
+++ b/src/menu.h
@@ -190,7 +190,7 @@ class Menu: public ModalWindow
                                std::function<void()>&, std::function<bool()>&, bool&)> lineDataHandler;
     void addLines(int vmin, int vmax, lineDataHandler lineFn, std::function<bool(int)> isValid = nullptr, int step = 1);
 
-    typedef std::function<void(int, uint8_t*, std::string&,
+    typedef std::function<void(int, uint8_t*&, std::string&,
                                     std::function<void()>&, std::function<bool()>&, bool&)> ilineDataHandler;
     void addLines(int vmin, int vmax, ilineDataHandler lineFn, std::function<bool(int)> isValid = nullptr, int step = 1);
 

--- a/src/menu.h
+++ b/src/menu.h
@@ -223,7 +223,7 @@ class Menu: public ModalWindow
         waitHandler();
       }
     }
-    
+
   protected:
     MenuWindowContent* content;
     bool multiple;

--- a/src/menu.h
+++ b/src/menu.h
@@ -95,7 +95,7 @@ class MenuBody: public TableField
     void onEvent(event_t event) override;
     void onCancel() override;
 
-    void setLineCount(uint16_t rows);
+    void addLineCount(uint16_t rows);
     void addLine(const std::string &text, std::function<void()> onPress,
                  std::function<bool()> isChecked);
 
@@ -179,14 +179,20 @@ class Menu: public ModalWindow
 
     void setTitle(std::string text);
 
-    void setLineCount(uint16_t rows);
-
     void addLine(const std::string &text, std::function<void()> onPress,
-                 std::function<bool()> isChecked = nullptr, bool updatePos = true);
+                 std::function<bool()> isChecked = nullptr);
 
     void addLine(const uint8_t *icon_mask, const std::string &text,
                  std::function<void()> onPress,
-                 std::function<bool()> isChecked = nullptr, bool updatePos = true);
+                 std::function<bool()> isChecked = nullptr);
+
+    typedef std::function<void(int, std::string&,
+                               std::function<void()>&, std::function<bool()>&, bool&)> lineDataHandler;
+    void addLines(int vmin, int vmax, lineDataHandler lineFn, std::function<bool(int)> isValid = nullptr, int step = 1);
+
+    typedef std::function<void(int, uint8_t*, std::string&,
+                                    std::function<void()>&, std::function<bool()>&, bool&)> ilineDataHandler;
+    void addLines(int vmin, int vmax, ilineDataHandler lineFn, std::function<bool(int)> isValid = nullptr, int step = 1);
 
     void addSeparator();
 
@@ -217,14 +223,13 @@ class Menu: public ModalWindow
         waitHandler();
       }
     }
-
-    void updatePosition();
     
   protected:
     MenuWindowContent* content;
     bool multiple;
     Window * toolbar = nullptr;
     std::function<void()> waitHandler;
+    void updatePosition();
 
     void setOutline(Window* obj);
 };

--- a/src/menu.h
+++ b/src/menu.h
@@ -104,7 +104,7 @@ class MenuBody: public TableField
                  std::function<bool()> isChecked);
 
     void removeLines();
-    
+
     void setCancelHandler(std::function<void()> handler)
     {
       _onCancel = std::move(handler);

--- a/src/menu.h
+++ b/src/menu.h
@@ -156,6 +156,26 @@ class Menu: public ModalWindow
   friend class MenuBody;
 
   public:
+    class MenuLineDesc
+    {
+    public:
+      MenuLineDesc()
+      {
+        icon_mask = nullptr;
+        onPress = nullptr;
+        isChecked = nullptr;
+        selected = false;
+      }
+
+    public:
+      uint8_t *icon_mask;
+      std::string text;
+      std::function<void()> onPress;
+      std::function<bool()> isChecked;
+      bool selected;
+    };
+
+  public:
     explicit Menu(Window * parent, bool multiple = false);
 
 #if defined(DEBUG_WINDOWS)
@@ -186,13 +206,8 @@ class Menu: public ModalWindow
                  std::function<void()> onPress,
                  std::function<bool()> isChecked = nullptr);
 
-    typedef std::function<void(int, std::string&,
-                               std::function<void()>&, std::function<bool()>&, bool&)> lineDataHandler;
-    void addLines(int vmin, int vmax, lineDataHandler lineFn, std::function<bool(int)> isValid = nullptr, int step = 1);
-
-    typedef std::function<void(int, uint8_t*&, std::string&,
-                                    std::function<void()>&, std::function<bool()>&, bool&)> ilineDataHandler;
-    void addLines(int vmin, int vmax, ilineDataHandler lineFn, std::function<bool(int)> isValid = nullptr, int step = 1);
+    void addLines(int vmin, int vmax, std::function<MenuLineDesc(int)> lineFn,
+                  std::function<bool(int)> isValid = nullptr, int step = 1);
 
     void addSeparator();
 

--- a/src/menu.h
+++ b/src/menu.h
@@ -95,6 +95,7 @@ class MenuBody: public TableField
     void onEvent(event_t event) override;
     void onCancel() override;
 
+    void setLineCount(uint16_t rows);
     void addLine(const std::string &text, std::function<void()> onPress,
                  std::function<bool()> isChecked);
 
@@ -103,7 +104,7 @@ class MenuBody: public TableField
                  std::function<bool()> isChecked);
 
     void removeLines();
-
+    
     void setCancelHandler(std::function<void()> handler)
     {
       _onCancel = std::move(handler);
@@ -178,12 +179,14 @@ class Menu: public ModalWindow
 
     void setTitle(std::string text);
 
+    void setLineCount(uint16_t rows);
+
     void addLine(const std::string &text, std::function<void()> onPress,
-                 std::function<bool()> isChecked = nullptr);
+                 std::function<bool()> isChecked = nullptr, bool updatePos = true);
 
     void addLine(const uint8_t *icon_mask, const std::string &text,
                  std::function<void()> onPress,
-                 std::function<bool()> isChecked = nullptr);
+                 std::function<bool()> isChecked = nullptr, bool updatePos = true);
 
     void addSeparator();
 
@@ -215,12 +218,13 @@ class Menu: public ModalWindow
       }
     }
 
+    void updatePosition();
+    
   protected:
     MenuWindowContent* content;
     bool multiple;
     Window * toolbar = nullptr;
     std::function<void()> waitHandler;
-    void updatePosition();
 
     void setOutline(Window* obj);
 };


### PR DESCRIPTION
Speeding up the init of the menus.
- [x] Menu interface
- [x] FileChoice::openMenu()
- [x] Choice::fillMenu()

In EdgeTX (these will be in an other PR):
- [x] ModelSetupPage::build()
- [x] ModelsPageBody::editLabels()
- [x] ModelCurvesPage::build()
- [x] ModelMixesPage::newMix()