### PR TITLE
fix(drawSizedText): stop trying to be smart about text clipping

### DIFF
--- a/src/bitmapbuffer.cpp
+++ b/src/bitmapbuffer.cpp
@@ -1101,13 +1101,6 @@ coord_t BitmapBuffer::drawSizedText(coord_t x, coord_t y, const char *s,
   strncpy(buffer, s, len);
   buffer[len] = '\0';
 
-  int height = getFontHeight(flags);
-
-  if (y + height <= ymin || y >= ymax) {
-    RESTORE_OFFSET();
-    return x;
-  }
-
   coord_t pos = x;
   const coord_t orig_pos = pos;
 


### PR DESCRIPTION
This fixes cases where a multi-line text has the first outside the clipping zone, while additional lines might be inside.

<img width="481" alt="Screenshot 2022-11-04 at 08 55 59" src="https://user-images.githubusercontent.com/1050031/199924427-6ee0ca5b-38db-47d2-93b7-13d894fc4574.png">
