### PR TITLE
add setters for DynamicNumber prefix and suffix texts

### DIFF
--- a/src/static.h
+++ b/src/static.h
@@ -178,6 +178,16 @@ class DynamicNumber : public StaticText
     }
   }
 
+  void setPrefix(const char * value) {
+    prefix = value;
+    updateText();
+  }
+
+  void setSuffix(const char * value) {
+    suffix = value;
+    updateText();
+  }
+
  protected:
   T value = 0;
   std::function<T()> numberHandler;


### PR DESCRIPTION
required by RX stat labeling on range check, rf tuning, low/critical warning pages. see EdgeTX PR [#3523](https://github.com/EdgeTX/edgetx/pull/3523)